### PR TITLE
remove configuration of pool_logger

### DIFF
--- a/gremlinclient/aiohttp_client/client.py
+++ b/gremlinclient/aiohttp_client/client.py
@@ -179,9 +179,8 @@ class Pool(Pool):
         object. used with ssl
     """
     def __init__(self, url, timeout=None, username="", password="",
-                 maxsize=256, loop=None, log_level=WARNING,
-                 future_class=None, force_release=False,
-                 connector=None):
+                 maxsize=256, loop=None, future_class=None,
+                 force_release=False, connector=None):
         graph = GraphDatabase(url,
                               timeout=timeout,
                               username=username,
@@ -190,7 +189,6 @@ class Pool(Pool):
                               loop=loop,
                               connector=connector)
         super(Pool, self).__init__(graph, maxsize=maxsize, loop=loop,
-                                   log_level=log_level,
                                    force_release=force_release,
                                    future_class=future_class)
 

--- a/gremlinclient/pool.py
+++ b/gremlinclient/pool.py
@@ -27,7 +27,7 @@ class Pool(object):
         :py:class:`tornado.concurrent.Future`
     """
     def __init__(self, graph, maxsize=256, loop=None, force_release=False,
-                 log_level=WARNING, future_class=None):
+                 future_class=None):
         self._graph = graph
         self._maxsize = maxsize
         self._pool = collections.deque()
@@ -38,7 +38,6 @@ class Pool(object):
         self._loop = loop
         self._force_release = force_release
         self._future_class = self._graph.future_class
-        pool_logger.setLevel(log_level)
 
     @property
     def freesize(self):

--- a/gremlinclient/requests/requests.py
+++ b/gremlinclient/requests/requests.py
@@ -164,10 +164,10 @@ class GraphDatabase(GraphDatabase):
 class Pool(Pool):
     def __init__(self, url, timeout=None, username="", password="",
                  maxsize=256, loop=None, force_release=False,
-                 log_level=WARNING, future_class=None):
+                 future_class=None):
         super().__init__(url, timeout=timeout, username=username,
                          password=password, graph_class=GraphDatabase,
-                         maxsize=maxsize, loop=loop, log_level=log_level)
+                         maxsize=maxsize, loop=loop)
 
     def close(self):
         self._graph.close()

--- a/gremlinclient/tornado_client/client.py
+++ b/gremlinclient/tornado_client/client.py
@@ -156,7 +156,7 @@ class Pool(Pool):
     """
     def __init__(self, url, graph=None, timeout=None, username="",
                  password="", maxsize=256, loop=None, force_release=False,
-                 log_level=WARNING, future_class=None, connector=None):
+                 future_class=None, connector=None):
         graph = GraphDatabase(url,
                               timeout=timeout,
                               username=username,
@@ -165,7 +165,6 @@ class Pool(Pool):
                               loop=loop,
                               connector=connector)
         super(Pool, self).__init__(graph, maxsize=maxsize, loop=loop,
-                                   log_level=log_level,
                                    force_release=force_release,
                                    future_class=future_class)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -1,7 +1,6 @@
 import uuid
 import unittest
 from datetime import timedelta
-from logging import DEBUG
 
 import tornado
 from tornado import gen
@@ -12,9 +11,6 @@ from tornado.testing import gen_test, AsyncTestCase
 from gremlinclient.connection import Stream
 from gremlinclient.tornado_client import (
     submit, GraphDatabase, Pool, create_connection, Response)
-
-
-LOG_LEVEL = DEBUG
 
 
 class TornadoFactoryConnectTest(AsyncTestCase):
@@ -145,8 +141,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         connection = yield pool.acquire()
         conn = connection.conn
         self.assertFalse(conn.closed)
@@ -168,8 +163,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         connection = yield pool.acquire()
         resp = connection.send("1 + 1")
         while True:
@@ -185,8 +179,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         c1 = yield pool.acquire()
         c2 = yield pool.acquire()
         c3 = pool.acquire()
@@ -201,8 +194,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         self.assertEqual(len(pool.pool), 0)
         c1 = yield pool.acquire()
         self.assertEqual(len(pool._acquired), 1)
@@ -215,8 +207,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         c1 = yield pool.acquire()
         yield pool.release(c1)
         c2 = yield pool.acquire()
@@ -227,12 +218,10 @@ class TornadoPoolTest(AsyncTestCase):
         pool1 = Pool("ws://localhost:8182/",
                      maxsize=2,
                      username="stephen",
-                     password="password",
-                     log_level=LOG_LEVEL)
+                     password="password")
         pool2 = Pool("ws://localhost:8182/",
                      username="stephen",
-                     password="password",
-                     log_level=LOG_LEVEL)
+                     password="password")
         conn1 = yield pool1.acquire()
         conn2 = yield pool2.acquire()
         conn3 = yield pool2.acquire()
@@ -248,8 +237,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         self.assertEqual(len(pool.pool), 0)
         c1 = yield pool.acquire()
         self.assertEqual(len(pool._acquired), 1)
@@ -264,8 +252,7 @@ class TornadoPoolTest(AsyncTestCase):
                     maxsize=2,
                     username="stephen",
                     password="password",
-                    force_release=True,
-                    log_level=LOG_LEVEL)
+                    force_release=True)
         self.assertEqual(len(pool.pool), 0)
         c1 = yield pool.acquire()
         self.assertEqual(len(pool._acquired), 1)
@@ -279,8 +266,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         c1 = yield pool.acquire()
         c2 = yield pool.acquire()
         c3 = pool.acquire()
@@ -299,8 +285,7 @@ class TornadoPoolTest(AsyncTestCase):
         pool = Pool("ws://localhost:8182/",
                     maxsize=2,
                     username="stephen",
-                    password="password",
-                    log_level=LOG_LEVEL)
+                    password="password")
         c1 = yield pool.acquire()
         c2 = yield pool.acquire()
         yield pool.release(c2)


### PR DESCRIPTION
This allows the app developer to configure the pool_logger; previously it wasn't possible to override the default log level of WARNING when using the pool class indirectly (e.g. with goblin, where the user passes a pool class but doesn't instantiate it directly).